### PR TITLE
sprint #5: draft survey edits

### DIFF
--- a/src/pages/survey/CreateChallengeSurvey.tsx
+++ b/src/pages/survey/CreateChallengeSurvey.tsx
@@ -47,6 +47,7 @@ export default function CreateChallengeSurvey() {
     surveyTitle?: string
     surveyDescription?: string
     surveyType?: 'Challenge' | 'Pulse' | 'challenge' | 'pulse'
+    surveyId?: string
   }
 
   const normalizedSurveyType =
@@ -117,14 +118,16 @@ export default function CreateChallengeSurvey() {
   const [tab, setTab] = useState<'question' | 'list' | 'workflow'>(
     incomingState.activeTab ?? incomingState.defaultTab ?? 'question'
   )
-  const [createdSurveyId, setCreatedSurveyId] = useState<string | null>(null)
+  const [createdSurveyId, setCreatedSurveyId] = useState<string | null>(
+    incomingState.surveyId ?? null
+  )
   const hasCreatedDraftRef = useRef(false) // prevents duplicate creations from effect reruns
 
   const navigate = useNavigate()
 
   useEffect(() => {
-    // checks if a draft already exists in this session or mismatched auth
-    if (hasCreatedDraftRef.current || !user) {
+    // checks if a draft already exists in this session, incoming surveyId exists, or mismatched auth
+    if (hasCreatedDraftRef.current || incomingState.surveyId || !user) {
       return
     }
 


### PR DESCRIPTION
included surveyID in incoming state, updated code to check for existing surveyID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Survey creation workflow now supports initializing with an existing survey, preventing unnecessary draft duplication during the creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->