### PR TITLE
school-personnel and district admin can view account page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,16 +69,19 @@ export default function App() {
             <Route path="/analytics" element={<Analytics />} />
           </Route>
 
-          {/* NSCC admin-only */}
-          <Route element={<ProtectedRoute requiredAction="manage_users" />}>
-            <Route path="/surveys" element={<AllSurveys />} />
-            <Route path="/surveys/:surveyId" element={<SurveyDetails />} />
-            <Route path="/manage-users" element={<ManageUsers />} />
+          <Route element={<ProtectedRoute requiredAction="read" />}>
             <Route path="/account" element={<Account />} />
             <Route
               path="/account/change-password"
               element={<ChangePassword />}
             />
+          </Route>
+
+          {/* NSCC admin-only */}
+          <Route element={<ProtectedRoute requiredAction="manage_users" />}>
+            <Route path="/surveys" element={<AllSurveys />} />
+            <Route path="/surveys/:surveyId" element={<SurveyDetails />} />
+            <Route path="/manage-users" element={<ManageUsers />} />
           </Route>
           {/* <Route path="/demo" element={<DatabaseDemo />} /> */}
         </Route>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account pages are now available under the standard read-access area, so signed-in users can access profile and password change settings more consistently.
  * Admin-only navigation now focuses on survey and user management pages, reducing access confusion between account settings and management tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->